### PR TITLE
feat: Toggle UI on and off by repeating the command

### DIFF
--- a/Peeping Tom/Plugin.cs
+++ b/Peeping Tom/Plugin.cs
@@ -78,9 +78,9 @@ namespace PeepingTom {
 
         private void OnCommand(string command, string args) {
             if (args is "config" or "c") {
-                Ui.SettingsWindow.IsOpen = true;
+                Ui.SettingsWindow.IsOpen = !Ui.SettingsWindow.IsOpen;
             } else {
-                Ui.MainWindow.IsOpen = true;
+                Ui.MainWindow.IsOpen = !Ui.MainWindow.IsOpen;
             }
         }
 


### PR DESCRIPTION
A simple change that allows closing the UI when running `/ppeepingtom` (and aliases) when the UI is open. Makes it possible to create macros that toggle the window open and closed when clicked several times.