### PR TITLE
Update to API14 and NET10

### DIFF
--- a/Peeping Tom.Ipc/Peeping Tom.Ipc.csproj
+++ b/Peeping Tom.Ipc/Peeping Tom.Ipc.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows</TargetFramework>
-        <Version>2.0.0</Version>
+        <TargetFramework>net10.0-windows</TargetFramework>
+        <Version>2.1.0</Version>
         <Nullable>enable</Nullable>
         <RootNamespace>PeepingTom.Ipc</RootNamespace>
     </PropertyGroup>

--- a/Peeping Tom/Peeping Tom.csproj
+++ b/Peeping Tom/Peeping Tom.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <RootNamespace>PeepingTom</RootNamespace>
-        <Version>1.7.22</Version>
+        <Version>1.8.0</Version>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <AssemblyName>PeepingTom</AssemblyName>
@@ -59,7 +59,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="13.0.0" />
+        <PackageReference Include="DalamudPackager" Version="14.0.1" />
         <PackageReference Include="Fody" Version="6.9.1" PrivateAssets="all" />
         <PackageReference Include="NAudio.Core" Version="2.2.1"/>
         <PackageReference Include="NAudio.Wasapi" Version="2.2.1"/>

--- a/Peeping Tom/PeepingTom.yaml
+++ b/Peeping Tom/PeepingTom.yaml
@@ -3,3 +3,6 @@ name: Peeping Tom
 punchline: Shows who is currently or was previously targeting you.
 description: Shows who is currently or was previously targeting you.
 repo_url: https://github.com/Caraxi/PeepingTom
+tags:
+- targeting
+- utility

--- a/Peeping Tom/packages.lock.json
+++ b/Peeping Tom/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net9.0-windows7.0": {
+    "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[13.0.0, )",
-        "resolved": "13.0.0",
-        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
+        "requested": "[14.0.1, )",
+        "resolved": "14.0.1",
+        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
       },
       "Fody": {
         "type": "Direct",


### PR DESCRIPTION
- Updated project target framework to **.NET 10** and Dalamud **API 14**.
- Added required `tags` to `PeepingTom.yaml` to resolve the manifest validation error in the latest Dalamud build.
- Updated dependencies and IPC version to match the new environment.